### PR TITLE
Fix: make importance resampling robust to importance samples with weight log(0)

### DIFF
--- a/test/gen/inference/importance_test.cljc
+++ b/test/gen/inference/importance_test.cljc
@@ -1,0 +1,23 @@
+(ns gen.inference.importance-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [gen.choicemap :as choicemap :refer [choicemap get-value]]
+            [gen.distribution.kixi :as dist]
+            [gen.dynamic :as dynamic :refer [gen]]
+            [gen.inference.importance :as importance]
+            [gen.trace :as trace]))
+
+(def model-causing-rejection-sampling
+  (gen
+    []
+    (if (dynamic/trace! :foo dist/bernoulli 0.5)
+      (dynamic/trace! :bar dist/bernoulli 1.0)
+      (dynamic/trace! :bar dist/bernoulli 0.0))))
+
+(deftest rejection
+  (testing "Robustness in the presence of importance samples with weight log(0)."
+    (is {:foo true :bar true}
+        ;; Needs a couple of samples to trigger previous bug here.
+        (-> (importance/resampling model-causing-rejection-sampling [] (choicemap {:bar true}) 10)
+            (:trace)
+            (trace/get-choices)
+            (get-value)))))


### PR DESCRIPTION
## What does this do?

Fixes a bug in importance resampling. Before, importance resampling crashed if any samples had a weight = log(0). But that should be a fine case for importance resampling to handle.  In this case, importance sampling should act like rejection sampling and never return those samples.

## How was this tested?

I've added a test in a separate commit.
